### PR TITLE
Add checkbox to PR template for signed commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -59,6 +59,7 @@ name / company / position / created at
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] All the commits are signed.
 - [ ] My code follows the code style of this project.
 - [ ] I agree with die CLA.
 - [ ] I have read the CONTRIBUTING docs.


### PR DESCRIPTION
## Type of request
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring 
- [x] Documentation or documentation changes

## Related Issue(s)

None.

## Concept 

As it is not always a requirement in open source projects to have signed all the commits to contribute to a PR, it might be useful to explicitly add a checkbox to inform and be sure that the contributor have signed the commits.

#### Description of the change

Add a checkbox to the PR template to be sure that developer and maintainer checks that signed-commits are required.

#### Description of current state

Sometimes developer/maintainers forget to sign commits and PR are blocked due to that.

#### Description of target state

Reduce the number of cases where the PR initiator needs to re-sign commits before merging into master.

#### Estimated investment / approximate investment

Irrelevant.

#### Initiator

Maintainer


## Technical information
#### Platform / target area

Maintenance

#### known side-effects
#### other 
#### DB Changes (if so: incl. scripts with definitions and testdata)		

#### How has this Tested?

Irrelevant

#### Screenshots, Uploads, other documents (if appropriate):
<!--- describe the uploaded documents -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I agree with die CLA.
- [x] I have read the CONTRIBUTING docs.
- [x] I have added/updated necessary documentation (if appropriate).