### PR TITLE
Redo PR#39

### DIFF
--- a/org.aposin.licensescout.core/sql/licensescout.sql
+++ b/org.aposin.licensescout.core/sql/licensescout.sql
@@ -28,7 +28,7 @@ SET time_zone = "+00:00";
 -- Tabellenstruktur für Tabelle `Builds`
 --
 
-CREATE TABLE `Builds` (
+CREATE TABLE "Builds" (
   `Id` int(11) NOT NULL,
   `Buildname` varchar(255) NOT NULL,
   `Version` varchar(255) NOT NULL,
@@ -45,7 +45,7 @@ CREATE TABLE `Builds` (
 -- Tabellenstruktur für Tabelle `DetectedLicenses`
 --
 
-CREATE TABLE `DetectedLicenses` (
+CREATE TABLE "DetectedLicenses" (
   `Id` int(11) NOT NULL,
   `FK_LibraryData_Id` int(11) NOT NULL,
   `License_Name` varchar(500) NOT NULL
@@ -57,7 +57,7 @@ CREATE TABLE `DetectedLicenses` (
 -- Tabellenstruktur für Tabelle `LibraryData`
 --
 
-CREATE TABLE `LibraryData` (
+CREATE TABLE "LibraryData" (
   `Id` int(11) NOT NULL,
   `FK_Build_Id` int(11) NOT NULL,
   `Selected_License` varchar(500) NOT NULL,
@@ -78,19 +78,19 @@ CREATE TABLE `LibraryData` (
 --
 -- Indizes für die Tabelle `Builds`
 --
-ALTER TABLE `Builds`
+ALTER TABLE "Builds"
   ADD PRIMARY KEY (`Id`);
 
 --
 -- Indizes für die Tabelle `DetectedLicenses`
 --
-ALTER TABLE `DetectedLicenses`
+ALTER TABLE "DetectedLicenses"
   ADD PRIMARY KEY (`Id`);
 
 --
 -- Indizes für die Tabelle `LibraryData`
 --
-ALTER TABLE `LibraryData`
+ALTER TABLE "LibraryData"
   ADD PRIMARY KEY (`Id`);
 
 --

--- a/org.aposin.licensescout.core/src/main/java/org/aposin/licensescout/archive/ArchiveIdentifier.java
+++ b/org.aposin.licensescout.core/src/main/java/org/aposin/licensescout/archive/ArchiveIdentifier.java
@@ -15,6 +15,8 @@
  */
 package org.aposin.licensescout.archive;
 
+import java.util.Objects;
+
 /**
  * Base class for Identifier for an archive bases on name.
  * 
@@ -70,44 +72,18 @@ public abstract class ArchiveIdentifier {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (!(o instanceof ArchiveIdentifier)) { return false; }
+        ArchiveIdentifier that = (ArchiveIdentifier) o;
+        return getArchiveType() == that.getArchiveType() &&
+            getNameMatchingType() == that.getNameMatchingType() &&
+            Objects.equals(getName(), that.getName());
+    }
+
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((archiveType == null) ? 0 : archiveType.hashCode());
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        return result;
+        return Objects.hash(getArchiveType(), getNameMatchingType(), getName());
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        ArchiveIdentifier other = (ArchiveIdentifier) obj;
-        if (archiveType != other.archiveType) {
-            return false;
-        }
-        if (name == null) {
-            if (other.name != null) {
-                return false;
-            }
-        } else if (!name.equals(other.name)) {
-            return false;
-        }
-        return true;
-    }
-
 }

--- a/org.aposin.licensescout.core/src/main/java/org/aposin/licensescout/archive/ArchiveIdentifierVersion.java
+++ b/org.aposin.licensescout.core/src/main/java/org/aposin/licensescout/archive/ArchiveIdentifierVersion.java
@@ -15,6 +15,8 @@
  */
 package org.aposin.licensescout.archive;
 
+import java.util.Objects;
+
 /**
  * Identifier for an archive bases on name and version.
  * 
@@ -42,52 +44,17 @@ public class ArchiveIdentifierVersion extends ArchiveIdentifier {
         return version;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (!(o instanceof ArchiveIdentifierVersion)) { return false; }
+        if (!super.equals(o)) { return false; }
+        ArchiveIdentifierVersion that = (ArchiveIdentifierVersion) o;
+        return Objects.equals(getVersion(), that.getVersion());
+    }
+
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((getArchiveType() == null) ? 0 : getArchiveType().hashCode());
-        result = prime * result + ((getName() == null) ? 0 : getName().hashCode());
-        result = prime * result + ((version == null) ? 0 : version.hashCode());
-        return result;
+        return Objects.hash(super.hashCode(), getVersion());
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        ArchiveIdentifierVersion other = (ArchiveIdentifierVersion) obj;
-        if (getArchiveType() != other.getArchiveType()) {
-            return false;
-        }
-        if (getName() == null) {
-            if (other.getName() != null) {
-                return false;
-            }
-        } else if (!getName().equals(other.getName())) {
-            return false;
-        }
-        if (version == null) {
-            if (other.version != null) {
-                return false;
-            }
-        } else if (!version.equals(other.version)) {
-            return false;
-        }
-        return true;
-    }
-
 }


### PR DESCRIPTION
Redoing with signed commits.
Remove the ` quote and use double quote for Table names in SQL.
Added a newer equals and hashCode in ArchiveIdentifierVersion.

## Type of request
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring 
- [ ] Documentation or documentation changes

## Related Issue(s)
Relates to #35 

## Concept 
This fixes a few issues in the following code quality issues:
https://app.codacy.com/manual/aposin-bot/LicenseScout/issues?bid=12903434&filters=W3siaWQiOiJDYXRlZ29yeSIsInZhbHVlcyI6WyJFcnJvclByb25lIl19XQ==

#### Initiator
Luiz Henrique Pegoraro / github.com/lpegoraro

#### How has this Tested?
Ran SQL locally in dockerized MySQL db.
Ran unit tests in core module.
![Screenshot_20191001_112455](https://user-images.githubusercontent.com/6593889/65971152-27e5fd00-e43e-11e9-8362-3efea6c9c59e.png)


## Checklist:
- [x] My code follows the code style of this project.
- [x] I agree with die CLA.
- [x] I have read the CONTRIBUTING docs.
- [ ] I have added/updated necessary documentation (if appropriate). (N/A)