### PR TITLE
Add tests for VendorArchiveListFilter

### DIFF
--- a/org.aposin.licensescout.core/src/test/java/org/aposin/licensescout/filter/VendorArchiveListFilterTest.java
+++ b/org.aposin.licensescout.core/src/test/java/org/aposin/licensescout/filter/VendorArchiveListFilterTest.java
@@ -33,29 +33,29 @@ public class VendorArchiveListFilterTest {
 	@Test
 	public void testFilterVendor() {
 		final VendorArchiveListFilter filter = new VendorArchiveListFilter(Collections.singletonList(FILTERED_VENDOR), new NullLog(), true);
-		doTestFilter(filter, getMockedArchivesForVendor(FILTERED_VENDOR), 0);
+		assertFilterSize(filter, getMockedArchivesForVendor(FILTERED_VENDOR), 0);
 	}
 	
 	@Test
 	public void testNoFilterVendor() {
 		final VendorArchiveListFilter filter = new VendorArchiveListFilter(Collections.singletonList(FILTERED_VENDOR), new NullLog(), true);
-		doTestFilter(filter, getMockedArchivesForVendor(INCLUDED_VENDOR), 1);
+		assertFilterSize(filter, getMockedArchivesForVendor(INCLUDED_VENDOR), 1);
 	}
 	
 	@Test
 	public void testNoFilterSimilarVendor() {
 		final VendorArchiveListFilter filter = new VendorArchiveListFilter(Collections.singletonList(FILTERED_VENDOR), new NullLog(), true);
-		doTestFilter(filter, getMockedArchivesForVendor(FILTERED_VENDOR + " 2"), 1);
+		assertFilterSize(filter, getMockedArchivesForVendor(FILTERED_VENDOR + " 2"), 1);
 	}
 	
 	@Test
 	public void testFilterSeveral() {
 		final VendorArchiveListFilter filter = new VendorArchiveListFilter(Arrays.asList(FILTERED_VENDOR, FILTERED_VENDOR + " 2"), new NullLog(), true);
-		doTestFilter(filter, getMockedArchivesForVendor(FILTERED_VENDOR, INCLUDED_VENDOR, FILTERED_VENDOR + " 2", INCLUDED_VENDOR), 2);
+		assertFilterSize(filter, getMockedArchivesForVendor(FILTERED_VENDOR, INCLUDED_VENDOR, FILTERED_VENDOR + " 2", INCLUDED_VENDOR), 2);
 		
 	}
 	
-	private static void doTestFilter(final VendorArchiveListFilter filter, final List<Archive> archives, final int expectedSizeAfterFilter) {
+	private static void assertFilterSize(final VendorArchiveListFilter filter, final List<Archive> archives, final int expectedSizeAfterFilter) {
 		filter.filter(archives);
 		Assert.assertEquals(expectedSizeAfterFilter,  archives.size());
 	}

--- a/org.aposin.licensescout.core/src/test/java/org/aposin/licensescout/filter/VendorArchiveListFilterTest.java
+++ b/org.aposin.licensescout.core/src/test/java/org/aposin/licensescout/filter/VendorArchiveListFilterTest.java
@@ -1,0 +1,60 @@
+package org.aposin.licensescout.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.aposin.licensescout.archive.Archive;
+import org.aposin.licensescout.util.NullLog;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VendorArchiveListFilterTest {
+
+	private static final String FILTERED_VENDOR = "DO NOT INCLUDE";
+	private static final String INCLUDED_VENDOR = "INCLUDED";
+	
+	@Test
+	public void testFilterVendor() {
+		final VendorArchiveListFilter filter = new VendorArchiveListFilter(Collections.singletonList(FILTERED_VENDOR), new NullLog(), true);
+		doTestFilter(filter, getMockedArchivesForVendor(FILTERED_VENDOR), 0);
+	}
+	
+	@Test
+	public void testNoFilterVendor() {
+		final VendorArchiveListFilter filter = new VendorArchiveListFilter(Collections.singletonList(FILTERED_VENDOR), new NullLog(), true);
+		doTestFilter(filter, getMockedArchivesForVendor(INCLUDED_VENDOR), 1);
+	}
+	
+	@Test
+	public void testNoFilterSimilarVendor() {
+		final VendorArchiveListFilter filter = new VendorArchiveListFilter(Collections.singletonList(FILTERED_VENDOR), new NullLog(), true);
+		doTestFilter(filter, getMockedArchivesForVendor(FILTERED_VENDOR + " 2"), 1);
+	}
+	
+	@Test
+	public void testFilterSeveral() {
+		final VendorArchiveListFilter filter = new VendorArchiveListFilter(Arrays.asList(FILTERED_VENDOR, FILTERED_VENDOR + " 2"), new NullLog(), true);
+		doTestFilter(filter, getMockedArchivesForVendor(FILTERED_VENDOR, INCLUDED_VENDOR, FILTERED_VENDOR + " 2", INCLUDED_VENDOR), 2);
+		
+	}
+	
+	private static void doTestFilter(final VendorArchiveListFilter filter, final List<Archive> archives, final int expectedSizeAfterFilter) {
+		filter.filter(archives);
+		Assert.assertEquals(expectedSizeAfterFilter,  archives.size());
+	}
+	
+	private static final List<Archive> getMockedArchivesForVendor(final String... vendors) {
+		final List<Archive> archives = new ArrayList<>(vendors.length);
+		
+		for (final String vendor: vendors) {
+			final Archive archive = new Archive(null, null, null, null);
+			archive.setVendor(vendor);
+			archives.add(archive);
+		}
+		
+		return archives;
+	}
+
+}

--- a/org.aposin.licensescout.core/src/test/java/org/aposin/licensescout/filter/VendorArchiveListFilterTest.java
+++ b/org.aposin.licensescout.core/src/test/java/org/aposin/licensescout/filter/VendorArchiveListFilterTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019 Association for the promotion of open-source insurance software and for the establishment of open interface standards in the insurance industry (Verein zur Förderung quelloffener Versicherungssoftware und Etablierung offener Schnittstellenstandards in der Versicherungsbranche)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.aposin.licensescout.filter;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Increase the coverage of the project with tests for `VendorArchiveListFilter`

## Type of request
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
-  [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring 
- [ ] Documentation or documentation changes

## Related Issue(s)

#34 

## Concept 
<!--- Why is this change required? What problem does it solve? -->
#### Description of the change

Add `VendorArchiveListFilterTest`

#### Description of current state

No tests for `VendorArchiveListFilter`

#### Description of target state

Increase test coverage of `VendorArchiveListFilter`

#### Estimated investment / approximate investment
<!--- Full Time Equivalents / Lines of code / € costs or something like that -->

#### Initiator
name / company / position / created at


## Technical information
#### Platform / target area
<!--- What platform(s) is effected? -->

#### known side-effects
#### other 
#### DB Changes (if so: incl. scripts with definitions and testdata)
		


#### How has this Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Screenshots, Uploads, other documents (if appropriate):
<!--- describe the uploaded documents -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All the commits are signed.
- [x] My code follows the code style of this project.
- [x] I agree with die CLA.
- [x] I have read the CONTRIBUTING docs.
- [x] I have added/updated necessary documentation (if appropriate).
