### PR TITLE
Added check for jacoco result file

### DIFF
--- a/org.aposin.licensescout.core/pom.xml
+++ b/org.aposin.licensescout.core/pom.xml
@@ -96,6 +96,32 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>jacoco-file-check</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>test</phase>
+						<configuration>
+							<rules>
+								<requireFilesExist>
+									<files>
+										<file>${project.build.directory}/jacoco.exec</file>
+									</files>
+									<message>Jacoco result file ('target/jacoco.exec') is missing!</message>
+								</requireFilesExist>
+							</rules>
+							<fail>true</fail>
+							<skip>${skipTests}</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>
@@ -126,13 +152,6 @@
 				</executions>
 			</plugin>
 
-<!--
-NOTE: disabled because of CI build error 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
- -->
 			<!-- groupId: org.jacoco -->
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/org.aposin.licensescout.parent/pom.xml
+++ b/org.aposin.licensescout.parent/pom.xml
@@ -42,6 +42,7 @@
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
 		<maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
+		<maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
 		<maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
 		<maven-invoker-plugin.version>3.0.1</maven-invoker-plugin.version>
 		<maven-jar-plugin.version>2.4</maven-jar-plugin.version>
@@ -191,6 +192,11 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>${maven-deploy-plugin.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>${maven-enforcer-plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Added build step to make build fail if jacoco result file does not exist after phase test

<!--- Provide a general summary of your changes in the Title above -->

<!---  
*DO keep Pull Requests small so they can be easily reviewed.*
 *DO make sure your contribution fits the openness and scalability for future extensions*
 *DO make sure unit tests pass.*
 *DO make sure any public APIs are XML documented.*
 *DO make sure not to introduce any compiler warnings.*
 *AVOID making significant changes to the driver's overall architecture.*
*Delete the above section and the instructions in the sections below before submitting.* 
--->

## Type of request
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring 
- [ ] Documentation or documentation changes

## Related Issue(s)
Solves #76 

## Concept 
Using an additional Maven build step to check if the file jacoco.exec exists after the unit test execution
#### Description of the change
See above.
#### Description of current state
#### Description of target state

#### Estimated investment / approximate investment
<!--- Full Time Equivalents / Lines of code / € costs or something like that -->

#### Initiator
Matthias Pfisterer


## Technical information
#### Platform / target area
<!--- What platform(s) is effected? -->

#### known side-effects
#### other 
#### DB Changes (if so: incl. scripts with definitions and testdata)
		


#### How has this Tested?
Running maven locally with clean install

#### Screenshots, Uploads, other documents (if appropriate):
<!--- describe the uploaded documents -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All the commits are signed.
- [x] My code follows the code style of this project.
- [x] I agree with die CLA.
- [x] I have read the CONTRIBUTING docs.
- [x] I have added/updated necessary documentation (if appropriate).
