### PR TITLE
Security update: commons-codec

### DIFF
--- a/licensescout-parent/pom.xml
+++ b/licensescout-parent/pom.xml
@@ -87,6 +87,7 @@
 		<!-- ================================ -->
 		<!-- Dependencies version definitions -->
 		<commons-beanutils.version>1.9.4</commons-beanutils.version>
+		<commons-codec.version>1.14</commons-codec.version>
 		<commons-collections4.version>4.4</commons-collections4.version>
 		<commons-lang3.version>3.9</commons-lang3.version>
 		<commons-io.version>2.6</commons-io.version>
@@ -195,7 +196,27 @@
 	</scm>
 
 	<dependencyManagement>
+
 		<dependencies>
+
+			<!-- groupId: commons-codec -->
+			<!-- NOTE: locking this transitive dependency due to a security issue: -->
+			<!-- https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518 -->
+
+			<!-- Introduced through: org.aposin.licensescout:licensescout-report-maven-plugin@1.4.${revision} -->
+			<!-- › org.apache.maven.doxia:doxia-core@1.9 › org.apache.httpcomponents:httpclient@4.5.8 -->
+			<!-- › commons-codec:commons-codec@1.11 -->
+
+			<!-- Newer versions of doxia and httpclient -->
+			<!-- still depend on the same version of commons-codec, so locking the -->
+			<!-- version of the transitive dependency is currently the only possible -->
+			<!-- solution. -->
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>${commons-codec.version}</version>
+			</dependency>
+
 			<!-- groupId: org.apache.maven -->
 			<dependency>
 				<groupId>org.apache.maven</groupId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 Updated version of commons-codec (transitive dependency in
licensescout-report-maven-plugin) to 1.14 because of known security
issues with version 1.11

The security alert that triggered this action:
https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518

The dependency is introduced by:

Detailed paths
Introduced through: org.aposin.licensescout:licensescout-report-maven-plugin@1.4.${revision} › org.apache.maven.doxia:doxia-core@1.9 › org.apache.httpcomponents:httpclient@4.5.8 › commons-codec:commons-codec@1.11
Remediation: No remediation path available.
Introduced through: org.aposin.licensescout:licensescout-report-maven-plugin@1.4.${revision} › org.apache.maven.doxia:doxia-site-renderer@1.9.1 › org.apache.maven.doxia:doxia-core@1.9 › org.apache.httpcomponents:httpclient@4.5.8 › commons-codec:commons-codec@1.11
Remediation: No remediation path available.
Introduced through: org.aposin.licensescout:licensescout-report-maven-plugin@1.4.${revision} › org.apache.maven.reporting:maven-reporting-impl@3.0.0 › org.apache.maven.doxia:doxia-core@1.9 › org.apache.httpcomponents:httpclient@4.5.8 › commons-codec:commons-codec@1.11
Remediation: No remediation path available.
Introduced through: org.aposin.licensescout:licensescout-report-maven-plugin@1.4.${revision} › org.apache.maven.reporting:maven-reporting-impl@3.0.0 › org.apache.maven.doxia:doxia-site-renderer@1.9.1 › org.apache.maven.doxia:doxia-core@1.9 › org.apache.httpcomponents:httpclient@4.5.8 › commons-codec:commons-codec@1.11
Remediation: No remediation path available.

Newer versions of doxia and httpclient still depend on the same version of commons-codec, so locking the version of the transitive dependency is currently the only possible solution.

<!---  
*DO keep Pull Requests small so they can be easily reviewed.*
 *DO make sure your contribution fits the openness and scalability for future extensions*
 *DO make sure unit tests pass.*
 *DO make sure any public APIs are XML documented.*
 *DO make sure not to introduce any compiler warnings.*
 *AVOID making significant changes to the driver's overall architecture.*
*Delete the above section and the instructions in the sections below before submitting.* 
--->

## Type of request
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring 
- [ ] Documentation or documentation changes

## Related Issue(s)
<!--- This project only accepts Pull Requests related to open Issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Concept 
<!--- Why is this change required? What problem does it solve? -->
#### Description of the change
<!--- Describe your changes in detail -->
#### Description of current state
#### Description of target state

#### Estimated investment / approximate investment
<!--- Full Time Equivalents / Lines of code / € costs or something like that -->

#### Initiator
Matthias Pfisterer


## Technical information
#### Platform / target area
<!--- What platform(s) is effected? -->

#### known side-effects
#### other 
#### DB Changes (if so: incl. scripts with definitions and testdata)
		


#### How has this Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Screenshots, Uploads, other documents (if appropriate):
<!--- describe the uploaded documents -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All the commits are signed.
- [x] My code follows the code style of this project.
- [x] I agree with die CLA.
- [x] I have read the CONTRIBUTING docs.
- [x] I have added/updated necessary documentation (if appropriate).
